### PR TITLE
Adds https://simpleotp.com to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Learn even more from reading interviews from SaaS founders with at least $500 MR
 - [Cal.com](https://cal.com) - Scheduling Infrastructure for Everyone.
 
 ### Authentification and User Management
+- [Simple OTP](https://simpleotp.com) - Easy passwordless (magic links, "enter a code") and passkey (WebAuthn/FIDO2) authentication for your website. Source code included.
 - [BoxyHQ](https://boxyhq.com) - Open source security building blocks for developers.
 - [Clerk](https://clerk.com) - The most comprehensive User Management Platform
 


### PR DESCRIPTION
Simple OTP is my passwordless auth startup, figured I'd add it to this directory. Built everything myself, all solo. 

Source code included (it's a self-hosted option) and it's a one time payment of $19 currently (soon to raise the price to $39, but still one time fee), so I believe it qualifies and will continue to qualify as affordable relative to all of the other popular authentication apps!

Thanks for putting this list together, @timb-103.